### PR TITLE
Add HangarFlying.com link to header navigation

### DIFF
--- a/resources/views/layouts/parts/header-links.blade.php
+++ b/resources/views/layouts/parts/header-links.blade.php
@@ -2,6 +2,8 @@
 
 @if (user()->hasAppAccess())
     <a class="hide-over-l" href="{{ url('/search') }}">@icon('search'){{ trans('common.search') }}</a>
+    <a href="https://hangarflying.com"
+       data-shortcut="settings_view">HangarFlying.com</a>
     @if(userCanOnAny('view', \BookStack\Entities\Models\Bookshelf::class) || userCan('bookshelf-view-all') || userCan('bookshelf-view-own'))
         <a href="{{ url('/shelves') }}"
            data-shortcut="shelves_view">@icon('bookshelf'){{ trans('entities.shelves') }}</a>


### PR DESCRIPTION
This update introduces a new link to HangarFlying.com in the header section for users with app access. The link includes a shortcut attribute for improved accessibility and usability. No existing functionality was altered.