### PR TITLE
Disable dark mode toggle in home view templates.

### DIFF
--- a/resources/views/home/books.blade.php
+++ b/resources/views/home/books.blade.php
@@ -24,7 +24,7 @@
                 <span>{{ trans('entities.tags_view_tags') }}</span>
             </a>
             @include('home.parts.expand-toggle', ['classes' => 'text-link', 'target' => '.entity-list.compact .entity-item-snippet', 'key' => 'home-details'])
-            @include('common.dark-mode-toggle', ['classes' => 'icon-list-item text-link'])
+{{--            @include('common.dark-mode-toggle', ['classes' => 'icon-list-item text-link'])--}}
         </div>
     </div>
 @stop

--- a/resources/views/home/shelves.blade.php
+++ b/resources/views/home/shelves.blade.php
@@ -24,7 +24,7 @@
                 <span>{{ trans('entities.tags_view_tags') }}</span>
             </a>
             @include('home.parts.expand-toggle', ['classes' => 'text-link', 'target' => '.entity-list.compact .entity-item-snippet', 'key' => 'home-details'])
-            @include('common.dark-mode-toggle', ['classes' => 'icon-list-item text-link'])
+{{--            @include('common.dark-mode-toggle', ['classes' => 'icon-list-item text-link'])--}}
         </div>
     </div>
 @stop

--- a/resources/views/home/specific-page.blade.php
+++ b/resources/views/home/specific-page.blade.php
@@ -21,7 +21,7 @@
         <h5>{{ trans('common.actions') }}</h5>
         <div class="icon-list text-link">
             @include('home.parts.expand-toggle', ['classes' => 'text-link', 'target' => '.entity-list.compact .entity-item-snippet', 'key' => 'home-details'])
-            @include('common.dark-mode-toggle', ['classes' => 'icon-list-item text-link'])
+{{--            @include('common.dark-mode-toggle', ['classes' => 'icon-list-item text-link'])--}}
         </div>
     </div>
 @stop


### PR DESCRIPTION
The dark mode toggle component is now commented out in multiple home-related Blade templates (`books`, `shelves`, and `specific-page`). This change likely serves as a temporary measure to suppress the feature while retaining the code for potential future use.