### PR TITLE
Disable guest user registration and login links temporarily.

### DIFF
--- a/resources/views/layouts/parts/header-links.blade.php
+++ b/resources/views/layouts/parts/header-links.blade.php
@@ -20,8 +20,8 @@
 @endif
 
 @if(user()->isGuest())
-    @if(setting('registration-enabled') && config('auth.method') === 'standard')
-        <a href="{{ url('/register') }}">@icon('new-user'){{ trans('auth.sign_up') }}</a>
-    @endif
-    <a href="{{ url('/login')  }}">@icon('login'){{ trans('auth.log_in') }}</a>
+{{--    @if(setting('registration-enabled') && config('auth.method') === 'standard')--}}
+{{--        <a href="{{ url('/register') }}">@icon('new-user'){{ trans('auth.sign_up') }}</a>--}}
+{{--    @endif--}}
+{{--    <a href="{{ url('/login')  }}">@icon('login'){{ trans('auth.log_in') }}</a>--}}
 @endif


### PR DESCRIPTION
Commented out the registration and login links for guest users in the header. This update may indicate an intended change in user accessibility or a feature deprecation in progress. Ensure this aligns with the overall authentication approach.