### PR TITLE
Change header icon color to gray for better contrast

### DIFF
--- a/resources/sass/_header.scss
+++ b/resources/sass/_header.scss
@@ -120,7 +120,7 @@ header .search-box {
   z-index: 1;
   inset-inline-start: 16px;
   top: 10px;
-  color: #FFF;
+  color: #707070;
   opacity: 0.6;
   @include lightDark(color, rgba(255, 255, 255, 0.8), #090909);
   svg {


### PR DESCRIPTION
Updated the header icon color from white to gray (#707070) to improve contrast and accessibility. This ensures better visibility and aligns with the design guidelines.